### PR TITLE
fixed bug with rate_onset and rate_decline

### DIFF
--- a/tests/xmhw_fixtures.py
+++ b/tests/xmhw_fixtures.py
@@ -171,14 +171,14 @@ def mhw_data():
         'duration_extreme': [0],
         'index_peak': [5.0],
         'intensity_var': [0.809938],
-        'intensity_max_relThresh': [np.nan],
-        'intensity_max_abs': [np.nan],
+        'intensity_max_relThresh': [1.40],
+        'intensity_max_abs': [19.6],
         'intensity_var_relThresh': [0.437035],
         'intensity_var_abs': [0.9495613],
         'category': [2.0],
         'duration': [6.0],
-        'rate_onset': [0.4818182],
-        'rate_decline': [4.6]}
+        'rate_onset': [0.5888889],
+        'rate_decline': [1.5333333]}
     for k,v in vars_dict.items():
         mhwds[k] = xr.DataArray(data=v, dims=['events'], coords={'events': [1]})
     return mhwds

--- a/xmhw/features.py
+++ b/xmhw/features.py
@@ -126,8 +126,8 @@ def properties(df, relT, mabs):
     df['index_peak'] = df.event + df.relS_imax
     df['intensity_var'] = np.sqrt(df.relS_var) 
     df['severity_var'] = np.sqrt(df.severity_var) 
-    df['intensity_max_relThresh'] = relT.iloc[df.index_peak.values]
-    df['intensity_max_abs'] = mabs.iloc[df.index_peak.values]
+    df['intensity_max_relThresh'] = relT[df.time_peak].values
+    df['intensity_max_abs'] = mabs[df.time_peak].values
     df['intensity_var_relThresh'] = np.sqrt(df.relT_var) 
     df['intensity_var_abs'] = np.sqrt(df.mabs_var) 
     df['category'] = np.minimum(df.cats_max, 4)
@@ -171,7 +171,8 @@ def get_period(start, end, peak, tsend):
 def onset_decline(df, last):
     """ Calculate rate of onset and decline for each MHW
     """
-    onset_period, decline_period = get_period(df.index_start, df.index_end, df.index_peak, last)
+    rel_index_peak = df.index_peak - df.index_start
+    onset_period, decline_period = get_period(df.index_start, df.index_end, rel_index_peak, last)
     relSeas_start = get_edge(df.relS_first, df.anom_first, df.index_start, 0)
     relSeas_end = get_edge(df.relS_last, df.anom_last, df.index_end, last)
     df['rate_onset'] =  get_rate(df.intensity_max, relSeas_start, onset_period)


### PR DESCRIPTION
Fixed bug in rate_decline and rate_onset calculation, now matches Eric's
Problem was I was passing index_peak which is the index relative to the entire time series as "tt_peak" which is meant to be the peak index relative to the event.
Also fixe disque with intensity_max_abs and intensity_max_relThresh 