### PR TITLE
added bthresh to intermediate results and fix issue with time/tdim

### DIFF
--- a/xmhw/identify.py
+++ b/xmhw/identify.py
@@ -187,7 +187,7 @@ def define_events(ds, idxarr,  minDuration, joinAcrossGaps, maxGap, intermediate
     mhw = xr.Dataset.from_dataframe(dfmhw, sparse=False)
     mhw_inter = None
     if intermediate:
-        df.drop(columns=['cell', 'time', 'start', 'end', 'anom_plus', 'anom_minus', 'bthresh'], inplace=True)
+        df.drop(columns=['cell', 'time', 'start', 'end', 'anom_plus', 'anom_minus'], inplace=True)
         mhw_inter = xr.Dataset.from_dataframe(df, sparse=False)
     return mhw, mhw_inter 
 

--- a/xmhw/xmhw.py
+++ b/xmhw/xmhw.py
@@ -279,7 +279,7 @@ def detect(temp, th, se, minDuration=5, joinAcrossGaps=True, maxGap=2, maxPadLen
     ds = ds.chunk(chunks={tdim: -1, 'cell': 1})
     # Build a pandas series with the positional indexes as values
     # [0,1,2,3,4,5,6,7,8,9,10,..]
-    idxarr = pd.Series(data=np.arange(len(ds[tdim])), index=ds.time.values)
+    idxarr = pd.Series(data=np.arange(len(ds[tdim])), index=ds[tdim].values)
     mhwls = []
     for c in ds.cell:
         mhwls.append(  define_events(ds.sel(cell=c), idxarr,


### PR DESCRIPTION
Forgot to change time to trim in idxarr creation in define_events() it's now fixed and added thresh to intermediate results