### PR TITLE
Fix issue 49

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.8.0" %}
+{% set version = "0.9.0" %}
 package:
     name: xmhw 
     version: {{ version }}

--- a/test/test_identify.py
+++ b/test/test_identify.py
@@ -172,6 +172,8 @@ def test_define_events(define_data, mhw_data, inter_data):
     )
     results = res.compute()
     xrtest.assert_allclose(results[0], mhwds)
+    print(results[1])
+    print(interds)
     xrtest.assert_allclose(results[1], interds)
 
     # test define events return one dataset only if intemediate is False, as default

--- a/test/test_identify.py
+++ b/test/test_identify.py
@@ -161,9 +161,9 @@ def test_define_events(define_data, mhw_data, inter_data):
     mhwds = mhw_data
     interds = inter_data
     res = define_events(
-        ts.isel(cell=0),
-        th.isel(cell=0),
-        se.isel(cell=0),
+        ts,
+        th,
+        se,
         idxarr,
         5,
         True,
@@ -172,15 +172,13 @@ def test_define_events(define_data, mhw_data, inter_data):
     )
     results = res.compute()
     xrtest.assert_allclose(results[0], mhwds)
-    print(results[1])
-    print(interds)
     xrtest.assert_allclose(results[1], interds)
 
     # test define events return one dataset only if intemediate is False, as default
     res = define_events(
-        ts.isel(cell=0),
-        th.isel(cell=0),
-        se.isel(cell=0),
+        ts,
+        th,
+        se,
         idxarr,
         5,
         True,

--- a/test/xmhw_fixtures.py
+++ b/test/xmhw_fixtures.py
@@ -189,28 +189,28 @@ def define_data():
     doy = xr.DataArray(
         data=[1, 2, 3, 4, 5, 6, 7, 8, 9], dims=["time"], coords={"time": time}
     )
+    lat = 45.5
+    lon = 123.4
     ts = xr.DataArray(
         data=[15.6, 17.3, 18.2, 19.5, 19.4, 19.6, 18.1, 17.0, 15.2],
         dims=["time"],
-        coords={"time": time, "doy": doy},
+        coords={"time": time, "doy": doy, "lat": lat, "lon": lon},
     )
-    # dims=['doy'], coords={'doy': doy, 'quantile':0.9})
     se = xr.DataArray(
         data=[15.8, 16.0, 16.2, 16.5, 16.6, 16.4, 16.6, 16.7, 16.4],
         dims=["doy"],
-        coords={"doy": ts["doy"].values},
+        coords={"doy": ts["doy"].values,
+               "lat": lat, "lon": lon},
     )
     th = xr.DataArray(
         [16.0, 16.7, 17.6, 17.9, 18.1, 18.2, 17.3, 17.2, 17.0],
         dims=["doy"],
-        coords={"doy": ts["doy"].values, "quantile": 0.9},
+        coords={"doy": ts["doy"].values, "lat":lat, "lon": lon,
+                "quantile": 0.9},
     )
-    ts = ts.expand_dims(["lat", "lon"])
-    ts = ts.stack(cell=(["lat", "lon"]))
-    se = se.expand_dims(["lat", "lon"])
-    th = th.expand_dims(["lat", "lon"])
-    se = se.stack(cell=(["lat", "lon"]))
-    th = th.stack(cell=(["lat", "lon"]))
+    ts = ts.stack(cell=(["lat", "lon"]), create_index=False)
+    se = se.stack(cell=(["lat", "lon"]), create_index=False)
+    th = th.stack(cell=(["lat", "lon"]), create_index=False)
     # Build a pandas series with the positional indexes as values
     # [0,1,2,3,4,5,6,7,8,9,10,..]
     idxarr = pd.Series(data=np.arange(9), index=ts.time.values)
@@ -253,6 +253,8 @@ def mhw_data():
         "duration": [6.0],
         "rate_onset": [0.5888889],
         "rate_decline": [1.5333333],
+        "lat": [45.5],
+        "lon": [123.4],
     }
     for k, v in vars_dict.items():
         mhwds[k] = xr.DataArray(
@@ -267,6 +269,8 @@ def inter_data():
     index = pd.date_range("2001-01-01", periods=9)
     ids = xr.Dataset(coords={"index": index})
     vars_dict = {
+        "lat": [45.5 for i in range(9)],
+        "lon": [123.4 for i in range(9)],
         "ts": [15.6, 17.3, 18.2, 19.5, 19.4, 19.6, 18.1, 17.0, 15.2],
         "seas": [np.nan, 16.0, 16.2, 16.5, 16.6, 16.4, 16.6, np.nan, np.nan],
         "thresh": [np.nan, 16.7, 17.6, 17.9, 18.1, 18.2, 17.3, np.nan, np.nan],

--- a/xmhw/identify.py
+++ b/xmhw/identify.py
@@ -510,7 +510,9 @@ def land_check(temp, tdim="time", anynans=False):
     for d in dims:
         if len(temp[d]) == 0:
             raise XmhwException(f"Dimension {d} has 0 lenght, exiting")
-    ts = temp.stack(cell=(dims))
+    # removing multi-index creation, as this was disappearing during percentile and mean operation anyway,
+    # and potentially slows down calculation
+    ts = temp.stack(cell=(dims), create_index=False)
     # drop cells that have all/any nan values along time
     how = "all"
     if anynans:

--- a/xmhw/stats.py
+++ b/xmhw/stats.py
@@ -240,10 +240,13 @@ def check_coordinates(dstime):
     # find name of time dimension
     # If there is already a stacked dimension skip land_check
     check = True
-    ds_coords = list(dstime.coords)
+    # now that we use a stacked array without crearting an index 
+    # the stacked coord is a dimension without coordinates
+    # and its type is int64 not anymore object
+    ds_coords = list(dstime.dims)
     for x in ds_coords:
         dtype = str(dstime[x].dtype)
-        if dtype == "object":
+        if dtype == "int64":
             stack_coord = x
             check = False
         elif "datetime" in dtype:

--- a/xmhw/xmhw.py
+++ b/xmhw/xmhw.py
@@ -345,7 +345,7 @@ def detect(
             + " be smaller than event minimum duration"
         )
     # if time dimension different from time, rename it
-    temp = temp.rename({tdim: "time"})
+    #temp = temp.rename({tdim: "time"})
     # save original attributes in a dictionary to assign to final dataset
     ds_attrs = {}
     ds_attrs["ts"] = temp.attrs
@@ -355,7 +355,7 @@ def detect(
 
     # Returns an array stacked on all dimensions excluded time, doy
     # Land cells are removed and new dimensions are (time,cell)
-    ts = land_check(temp, anynans=anynans)
+    ts = land_check(temp, tdim=tdim, anynans=anynans)
     del temp
     th = land_check(th, tdim="doy", anynans=anynans)
     se = land_check(se, tdim="doy", anynans=anynans)
@@ -373,7 +373,7 @@ def detect(
 
     # Build a pandas series with the positional indexes as values
     # [0,1,2,3,4,5,6,7,8,9,10,..]
-    idxarr = pd.Series(data=np.arange(len(ts.time)), index=ts.time.values)
+    idxarr = pd.Series(data=np.arange(len(ts[tdim])), index=ts[tdim].values)
 
     # Loop over each cell to detect MHW events, define_events()
     # is delayed, so loop is automatically run in parallel
@@ -389,18 +389,25 @@ def detect(
                 joinGaps,
                 maxGap,
                 intermediate,
+                tdim,
             )
         )
     results = dask.compute(mhwls)
 
     # Concatenate results and save as dataset
-    mhw_results = [r[0] for r in results[0]]
-    mhw = xr.concat(mhw_results, dim=ts.cell)
-    mhw = mhw.unstack("cell")
+    # re-assign dimensions previously used to stack arrays
+    dims = list(ts.cell.coords)
+    mhw_results = [r[0].assign_coords({d: r[0][d][0].values for d in dims}) for r in results[0]]
+    mhw = xr.concat(mhw_results, dim='cell')
+    # looks like I need to remove index (i.e. time) as a dimension first
+    mhw = mhw.set_xindex(dims)
+    mhw = mhw.unstack(dim='cell')
     if intermediate:
-        inter_results = [r[1] for r in results[0]]
-        mhw_inter = xr.concat(inter_results, dim=ts.cell).unstack("cell")
-        mhw_inter = mhw_inter.rename({"index": "time"})
+        inter_results = [r[1].assign_coords({d: r[1][d][0].values for d in dims}) for r in results[0]]
+        mhw_inter = xr.concat(inter_results, dim='cell')
+        mhw_inter = mhw_inter.set_xindex(dims)
+        mhw_inter = mhw_inter.unstack('cell')
+        mhw_inter = mhw_inter.rename({'index': 'time'})
         mhw_inter = mhw_inter.squeeze(drop=True)
     # if point dimension was added in land_check remove
     mhw = mhw.squeeze(drop=True)

--- a/xmhw/xmhw.py
+++ b/xmhw/xmhw.py
@@ -399,7 +399,6 @@ def detect(
     dims = list(ts.cell.coords)
     mhw_results = [r[0].assign_coords({d: r[0][d][0].values for d in dims}) for r in results[0]]
     mhw = xr.concat(mhw_results, dim='cell')
-    # looks like I need to remove index (i.e. time) as a dimension first
     mhw = mhw.set_xindex(dims)
     mhw = mhw.unstack(dim='cell')
     if intermediate:


### PR DESCRIPTION
To solve issue #49 caused by changes to the latest xarray:

* In land_check function when stacking dimensions land_check doesn't create anymore a multi-index ( this potentially should also speed up calculations), coordinates are added again before concatenating results.

In both threshold() and detect() was necessary to re-assign the coordinates, reset the "stacked" array using set_xindex to be able to unstack again, for example:
```{code}
   dims = list(ts.cell.coords)
   mhw_results = [r[0].assign_coords({d: r[0][d][0].values for d in dims}) for r in results[0]]
    mhw = xr.concat(mhw_results, dim='cell')
    mhw = mhw.set_xindex(dims)
    mhw = mhw.unstack(dim='cell')
```
* As after groupby.aggregate operation coordinates are completely lost, they need to be re-added in the aggdf() function.
* Finally the check_coordinates() function in stats.py had to be adapted as now the stacked dimension is a dimension without coordinate 
